### PR TITLE
fix: patch auto-merge to allow minor semver

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(steps.metadata.outputs.dependency-names, 'docker') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: contains(steps.metadata.outputs.dependency-names, 'docker') && (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
This adds a trigger for auto-merge if dependabot is trying to merge a minor version as well as a patch version.

this fixes the auto-merge non-trigger in https://github.com/synapsestudios/meat-runner/pull/22