### PR TITLE
fix bug where base image is cached

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           context: ${{ matrix.image_folder }}/.
           push: true
+          pull: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ steps.set_image_name.outputs.image_name }}:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/${{ steps.set_image_name.outputs.image_name }}:latest


### PR DESCRIPTION
this ensures that base images referenced in the docker file are always pulled and never used from cache, which ensures you get the latest version. This was causing a deprecation failure cascade bug in our actions runner controller cluster.
