### PR TITLE
feat(ci): add workflow_dispatch trigger to deploy workflow for manual image deployment trigger

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   create_matrix:


### PR DESCRIPTION
this is a temporary measure until dependabot is able to trigger workflows (dependabot by default cannot trigger workflows and requires special configuration in github actions to enable this behavior)
